### PR TITLE
Stop in-memory Datomic resetting when it shouldn't

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -97,11 +97,11 @@
     (fn [_] (reload/reload))
     (when (= mode :auto) (map io/file dirs))))
 
-#_(defn delete-datomic
-  "Takes a Datomic URI, stops the system and deletes the database.
+(defn delete-datomic
+ "Takes a Datomic URI, stops the system and deletes the database.
   Don't call this yourself, use hard-reset instead."
-  {:init/inject [:partial :datomic/uri]}
-  [uri]
-  (stop)
-  (await system)
-  (d/delete-database uri))
+ {:init/inject [:partial :datomic/uri]}
+ [uri]
+ (stop)
+ (await system)
+ (d/delete-database uri))

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,9 +1,9 @@
 (ns user
   (:require
     [clj-reload.core :as reload]
-    [clore.core]
     [clojure.java.io :as io]
     [clojure.repl :refer :all]
+    [clore.core]
     [datomic.api :as d]
     [init.core :as init]
     [init.discovery :as discovery]
@@ -98,10 +98,10 @@
     (when (= mode :auto) (map io/file dirs))))
 
 (defn delete-datomic
- "Takes a Datomic URI, stops the system and deletes the database.
+  "Takes a Datomic URI, stops the system and deletes the database.
   Don't call this yourself, use hard-reset instead."
- {:init/inject [:partial :datomic/uri]}
- [uri]
- (stop)
- (await system)
- (d/delete-database uri))
+  {:init/inject [:partial :datomic/uri]}
+  [uri]
+  (stop)
+  (await system)
+  (d/delete-database uri))

--- a/src/clore/datomic.clj
+++ b/src/clore/datomic.clj
@@ -6,8 +6,7 @@
 
 (defn connect
   {:init/inject [:datomic/uri :datomic/schema :datomic/fixtures]
-   :init/tags #{:datomic/conn}
-   :init/stop-fn #'d/release}
+   :init/tags #{:datomic/conn}}
   [uri schema fixtures]
   (d/create-database uri)
   (let [conn (d/connect uri)]


### PR DESCRIPTION
This should make the Datomic component behave as intended when using an in-memory db: keep the data on normal resets, wipe the data only when the user explicitly calls `hard-reset` from the REPL.